### PR TITLE
remove runtime dependency on rails 4

### DIFF
--- a/xliffle.gemspec
+++ b/xliffle.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "rails", "~> 4.1.4"
   s.add_dependency "builder"
 
   s.add_development_dependency "sqlite3"


### PR DESCRIPTION
rails 4 is a massive runtime dependency for a small utility. I skimmed the code and it seems to run fine without it.

Extra info:
I'm also considering adding support for descriptions: https://github.com/google/closure-templates/blob/master/examples/examples_translated_x-zz.xlf#L8
but after some more discussion we might not need this.
Thanks for the gem! I'm using it on https://translate.twitter.com now.
